### PR TITLE
Upgrade node to 22 and add provenance

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,5 +1,7 @@
 name: Node.js CI
 on: [push]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,9 +6,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '22.x'
       - run: npm install
       - run: npm run build --if-present
       - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
     types: [created]
 
 permissions:
+  contents: read
   id-token: write
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,14 +4,17 @@ on:
   release:
     types: [created]
 
+permissions:
+  id-token: write
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
       - run: npm ci
@@ -19,6 +22,6 @@ jobs:
       - run: npm version ${TAG_NAME} --git-tag-version=false
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-      - run: npm whoami; npm --ignore-scripts publish
+      - run: npm whoami; npm --ignore-scripts publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
Node 22 will be active LTS by the end of the month, so the following changes have been made:

- Updated the development container to use Node 22
- Updated Actions to use Node 22
- Update Actions to publish with [provenance](https://docs.npmjs.com/generating-provenance-statements)