### PR TITLE
Pin brace-expansion@1 to a patched release via override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1168,9 +1168,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5706,9 +5706,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -7220,7 +7220,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^1.1.18"
       }
     },
     "minimist": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "mocha": {
       "js-yaml": "^5.2.2",
       "serialize-javascript": "^7.0.5"
-    }
+    },
+    "brace-expansion@1": "^1.1.18"
   }
 }


### PR DESCRIPTION
Follow-up to #30, which cleared everything `npm audit fix` could reach. One high-severity `brace-expansion` finding remained — `npm audit fix` converges without moving the pinned transitive copy.

One copy was vulnerable:

| Path | Was | Now |
|---|---|---|
| `eslint-plugin-github` → `@eslint/eslintrc` → `minimatch@3` | `1.1.13` | `1.1.18` |

Adds a **version-scoped** override:

```json
"brace-expansion@1": "^1.1.18"
```

Scoping to the v1 line matters — a blanket override would drag the `2.1.4` (mocha) and `5.0.9` (eslint) copies onto the wrong major. Both of those are already on patched releases and are left untouched.

Resolves [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp), [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895).

### Still outstanding after this
Two **low** severity findings for `diff` ([GHSA-73rr-hh4g-fpgx](https://github.com/advisories/GHSA-73rr-hh4g-fpgx)) via `mocha`. There is no clean fix available:

- Every `mocha` release through the latest (`11.8.0`) declares `diff: ^7.0.0`, and the entire v7 line falls in the vulnerable `6.0.0 - 8.0.2` range.
- `npm audit fix --force` "fixes" it by **downgrading** mocha to `11.3.0`.
- Overriding to `diff@^8.0.4` pushes mocha past the major it declares support for.

This needs an upstream mocha bump. It is dev-only (test runner diff rendering), so leaving it.

### Validation
- `npm test` passes (build + lint + 18 tests)